### PR TITLE
Adding a feature to compare_means and solving the issue_435 for one case only

### DIFF
--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -104,7 +104,8 @@ NULL
 compare_means <- function(formula, data, method = "wilcox.test",
                           paired = FALSE,
                           group.by = NULL, ref.group = NULL,
-                          symnum.args = list(), p.adjust.method = "holm", ...)
+                          symnum.args = list(),
+                          p.adjust.method = "holm", p.format.adj = F, ...)
 {
 
   . <- NULL
@@ -227,12 +228,20 @@ compare_means <- function(formula, data, method = "wilcox.test",
   pvalue.signif <- do.call(stats::symnum, symnum.args) %>%
     as.character()
 
-  pvalue.format <- format.pval(res$p, digits = 2)
 
   .y. <- p.adj <- NULL
   .p.adjust <- function(d, ...) {data.frame(p.adj = stats::p.adjust(d$p, ...))}
   by_y <- res %>% group_by(.y.)
   pvalue.adj <- do(by_y, .p.adjust(., method = p.adjust.method))
+
+
+  if(p.format.adj){
+    pvalue.format <- format.pval(pvalue.adj$p.adj, digits = 2)
+  }
+  else{
+    pvalue.format <- format.pval(res$p, digits = 2)
+  }
+
   res <- res %>%
     dplyr::ungroup() %>%
     mutate(p.adj = pvalue.adj$p.adj, p.format = pvalue.format, p.signif = pvalue.signif,

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -52,7 +52,7 @@ NULL
 #'\item \code{p}: the p-value.
 #'\item \code{p.adj}: the adjusted p-value. Default for \code{p.adjust.method = "holm"}.
 #'\item \code{p.format}: the formatted p-value.
-#'\item \code{p..adj.format}: the formatted p-value adjusted.
+#'\item \code{p.adj.format}: the formatted p-value adjusted.
 #'\item \code{p.signif}: the significance level.
 #'\item \code{method}: the statistical test used to compare groups.
 #'

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -40,6 +40,8 @@ NULL
 #'@param bracket.size Width of the lines of the bracket.
 #'@param step.increase numeric vector with the increase in fraction of total
 #'  height for every additional comparison to minimize overlap.
+#'@param p.adjust.method method for adjusting p values. None by default. If a
+#'  method is specified, the adjusted p.value will be printed.
 #'@param ... other arguments to pass to \code{\link[ggplot2]{geom_text}} or
 #'  \code{\link[ggplot2:geom_text]{geom_label}}.
 #'@param na.rm If FALSE (the default), removes missing values with a warning. If
@@ -105,7 +107,9 @@ stat_compare_means <- function(mapping = NULL, data = NULL,
                      bracket.size = 0.3, step.increase = 0,
                      symnum.args = list(),
                      geom = "text", position = "identity",  na.rm = FALSE, show.legend = NA,
-                    inherit.aes = TRUE, ...) {
+                     inherit.aes = TRUE,
+                     p.adjust.method = NULL,
+                     ...) {
 
   if(!is.null(comparisons)){
 
@@ -207,6 +211,11 @@ StatCompareMeans<- ggproto("StatCompareMeans", Stat,
                                 paired = paired, ref.group = ref.group,
                                 symnum.args = symnum.args)
 
+                    if(!is.null(p.adjust.methods)){
+                      method.args <- method.args %>%
+                        .add_item(p.adjust.methods = p.adjust.methods)
+                    }
+
                     if(.is.multiple.grouping.vars){
                       method.args <- method.args %>%
                         .add_item(formula = y ~ group, group.by = "x")
@@ -218,9 +227,19 @@ StatCompareMeans<- ggproto("StatCompareMeans", Stat,
                       .test <- do.call(compare_means, method.args)
                     }
 
-                    pvaltxt <- ifelse(.test$p < 2.2e-16, "p < 2.2e-16",
-                                      paste("p =", signif(.test$p, 2)))
-                    .test$label <- paste(.test$method, pvaltxt, sep =  label.sep)
+                    if(is.null(p.adjust.methods)){
+                      pvaltxt <- ifelse(.test$p < 2.2e-16, "p < 2.2e-16",
+                                        paste("p =", signif(.test$p, 2)))
+                      .test$label <- paste(.test$method, pvaltxt, sep =  label.sep)
+                    }
+                    # If a method is specified for p.adj, we use the adjusted
+                    # p.value
+                    else{
+                      pvaltxt <- ifelse(.test$p.adj < 2.2e-16, "p < 2.2e-16",
+                                        paste("p =", signif(.test$p.adj, 2)))
+                      .test$label <- paste(.test$method, pvaltxt, sep =  label.sep)
+                    }
+
 
                     # Options for label positioning
                     #::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/ggpubr.Rproj
+++ b/ggpubr.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: b5b1b45f-efb9-4e73-b746-8234a0eec53b
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/ggpubr.Rproj
+++ b/ggpubr.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 38790098-a017-487a-b9ad-7868a008dc3b
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
In this update, we have added a column to the output of `compare_means` to include the formatted adjusted p-value. This addition will be usefull in the future in order to solve the original issue.

We also made it possible to choose a method for the adjusted p-value and to display it, but only for one case (see the last commit).